### PR TITLE
Allow to use in functional testing

### DIFF
--- a/src/SymfonyMiddleware.php
+++ b/src/SymfonyMiddleware.php
@@ -73,5 +73,7 @@ class SymfonyMiddleware implements HttpKernelInterface, TerminableInterface
     public function terminate(Request $request, Response $response)
     {
         $this->symfonyApp->terminate($request, $response);
+        $this->symfonyApp->shutdown();
+        $this->initDone = false;
     }
 }


### PR DESCRIPTION
Using stacked kernels within functional testing I got errors because the kernel was not shut down at the end of each request. 
This fix solved my issues, I'm not sure it is the only way (or the best way) to go though. I can't see any contraindication with this, 
but I have very little experience with stackPHP
